### PR TITLE
Specified utf-8 encoding for reading .ini file

### DIFF
--- a/puzzle-a-day.py
+++ b/puzzle-a-day.py
@@ -113,7 +113,7 @@ if __name__ == '__main__':
     # Validate the arguments
     starttime = time.time()
     puzzles = configparser.ConfigParser()
-    puzzles.read('puzzle-a-day.ini')
+    puzzles.read('puzzle-a-day.ini',encoding='utf-8')
     board = puzzles[opts.puzzle]['board']
     pieces = puzzles[opts.puzzle][opts.set]
     print(f'{board}\n{pieces}')


### PR DESCRIPTION
updated to script to explicitly state the encoding as 'utf-8' else the .ini file was read incorrectly leading to incorrect termination of the script